### PR TITLE
feat: add text-to-speech (TTS) support for response audio playback

### DIFF
--- a/emacs-openclaw-chat.el
+++ b/emacs-openclaw-chat.el
@@ -11,6 +11,7 @@
 (require 'emacs-openclaw-config)
 (require 'emacs-openclaw-websocket)
 (require 'emacs-openclaw-server)
+(require 'emacs-openclaw-tts)
 
 ;; Load mode module
 (require 'emacs-openclaw-mode)
@@ -92,7 +93,8 @@
    prompt
    (lambda (response)
      (let ((ok (alist-get 'ok response))
-           (msg-id (alist-get 'id response)))
+           (msg-id (alist-get 'id response))
+           (response-text nil))
        (if ok
            (progn
              ;; Only extract from res if no agent events were received
@@ -101,15 +103,18 @@
                (let* ((payload (alist-get 'payload response))
                       (result (alist-get 'result payload))
                       (payloads (alist-get 'payloads result))
-                      (first-payload (when (listp payloads) (car payloads)))
-                      (response-text (when first-payload (alist-get 'text first-payload))))
+                      (first-payload (when (listp payloads) (car payloads))))
+                 (setq response-text (when first-payload (alist-get 'text first-payload)))
                  (when response-text
                    (emacs-openclaw--log response-text nil)
                    (emacs-openclaw--log "\n" nil)
                    (emacs-openclaw--log (concat emacs-openclaw-message-separator "\n") 'shadow)
                    (emacs-openclaw--log "\n" nil))))
              ;; Clean up tracking
-             (remhash msg-id emacs-openclaw--active-requests))
+             (remhash msg-id emacs-openclaw--active-requests)
+             ;; Speak the response if TTS is enabled
+             (when response-text
+               (emacs-openclaw-tts-speak-response response-text)))
          (let ((error-data (alist-get 'error response)))
            (emacs-openclaw--log (format "\n[Error]: %s\n" error-data) 'error)
            (emacs-openclaw--log (concat emacs-openclaw-message-separator "\n") 'shadow)))))))

--- a/emacs-openclaw-tts.el
+++ b/emacs-openclaw-tts.el
@@ -1,0 +1,81 @@
+;;; emacs-openclaw-tts.el --- Text-to-speech integration for emacs-openclaw
+
+;; Copyright (C) 2026 Andres Laurito
+;; Author: Andres Laurito <andres@example.com>
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "27.1"))
+;; Keywords: openclaw tts speech
+
+;;; Commentary:
+
+;; Provides text-to-speech (TTS) functionality for emacs-openclaw responses.
+;; Uses the system `say` command on macOS for natural audio output.
+
+;;; Code:
+
+(defgroup emacs-openclaw-tts nil
+  "Text-to-speech settings for emacs-openclaw."
+  :group 'emacs-openclaw
+  :prefix "emacs-openclaw-tts-")
+
+(defcustom emacs-openclaw-tts-enabled nil
+  "Enable audio playback of responses."
+  :type 'boolean
+  :group 'emacs-openclaw-tts)
+
+(defcustom emacs-openclaw-tts-voice "Samantha"
+  "Voice to use for text-to-speech on macOS.
+Run `say -v '?' to see available voices."
+  :type 'string
+  :group 'emacs-openclaw-tts)
+
+(defcustom emacs-openclaw-tts-rate 150
+  "Speech rate in words per minute (default 150)."
+  :type 'integer
+  :group 'emacs-openclaw-tts)
+
+(defcustom emacs-openclaw-tts-command "say"
+  "Command to use for text-to-speech.
+Defaults to 'say' (macOS). Set to 'espeak' for Linux."
+  :type 'string
+  :group 'emacs-openclaw-tts)
+
+(defun emacs-openclaw-tts-speak (text)
+  "Speak TEXT using system TTS.
+Uses `say` on macOS or `espeak` on Linux."
+  (when (and text (not (string-empty-p text)))
+    (let* ((cmd emacs-openclaw-tts-command)
+           (voice-arg (if (string= cmd "say") "-v" "-v"))
+           (rate-arg (if (string= cmd "say") "-r" "--rate")))
+      (shell-command
+       (format "%s %s %s %s %d <<< %s"
+               cmd
+               voice-arg
+               emacs-openclaw-tts-voice
+               rate-arg
+               emacs-openclaw-tts-rate
+               (shell-quote-argument text))
+       nil
+       nil))))
+
+(defun emacs-openclaw-tts-speak-response (response)
+  "Speak RESPONSE if TTS is enabled.
+Called after inserting a full response in the chat buffer."
+  (when emacs-openclaw-tts-enabled
+    (emacs-openclaw-tts-speak response)))
+
+(defun emacs-openclaw-tts-toggle ()
+  "Toggle text-to-speech on/off."
+  (interactive)
+  (setq emacs-openclaw-tts-enabled (not emacs-openclaw-tts-enabled))
+  (message "OpenClaw TTS %s"
+           (if emacs-openclaw-tts-enabled "enabled" "disabled")))
+
+(defun emacs-openclaw-tts-list-voices ()
+  "List available voices on macOS."
+  (interactive)
+  (when (string= emacs-openclaw-tts-command "say")
+    (shell-command "say -v ?")))
+
+(provide 'emacs-openclaw-tts)
+;;; emacs-openclaw-tts.el ends here

--- a/emacs-openclaw.el
+++ b/emacs-openclaw.el
@@ -16,6 +16,9 @@
 ;; Optional features:
 ;; - Speech-to-text support via whisper.el (disabled by default)
 ;;   Set `emacs-openclaw-allow-speech-to-text' to t to enable.
+;; - Text-to-speech support via macOS `say` command (disabled by default)
+;;   Set `emacs-openclaw-tts-enabled' to t or use M-x emacs-openclaw-tts-toggle
+;;   to enable audio playback of responses.
 
 (require 'emacs-openclaw-config)
 (require 'emacs-openclaw-websocket)


### PR DESCRIPTION
- Create emacs-openclaw-tts.el module with configurable TTS settings
  - macOS 'say' command support (with voice and rate customization)
  - Linux 'espeak' support via config
  - Toggle TTS on/off with M-x emacs-openclaw-tts-toggle

- Integrate TTS into emacs-openclaw-chat.el
  - Auto-speak responses when emacs-openclaw-tts-enabled is true
  - Clean separation of concerns via dedicated module

- Update main module documentation with TTS feature info
- Maintain existing speech-to-text (STT) functionality