### PR TITLE
feat: display tool activity in Emacs chat buffer

### DIFF
--- a/emacs-openclaw-config.el
+++ b/emacs-openclaw-config.el
@@ -61,6 +61,14 @@ If nil, will be auto-detected from the main session key provided by the gateway.
   :type 'boolean
   :group 'emacs-openclaw)
 
+(defcustom emacs-openclaw-show-tool-activity t
+  "Whether to show tool call and result events in the chat buffer.
+When non-nil, tool invocations and their results are displayed in a
+dimmed style so you can see what the agent is doing.  Set to nil for
+a cleaner chat that only shows assistant text."
+  :type 'boolean
+  :group 'emacs-openclaw)
+
 (defcustom emacs-openclaw-python-executable "python3"
   "Python executable used to start the OpenClaw server.
 Defaults to \"python3\" (whatever is on your PATH), but you should set this

--- a/emacs-openclaw-websocket.el
+++ b/emacs-openclaw-websocket.el
@@ -6,6 +6,8 @@
 (require 'emacs-openclaw-config)
 (require 'emacs-openclaw-tts)
 
+(declare-function emacs-openclaw--log "emacs-openclaw-chat")
+
 (defvar emacs-openclaw--websocket nil)
 (defvar emacs-openclaw--websocket-connected nil)
 (defvar emacs-openclaw--request-id-counter 0)
@@ -24,6 +26,29 @@
 (defun emacs-openclaw--generate-request-id ()
   (setq emacs-openclaw--request-id-counter (1+ emacs-openclaw--request-id-counter))
   (format "emacs-req-%d" emacs-openclaw--request-id-counter))
+
+;; ============================================================================
+;; Tool Activity Faces and Helpers
+;; ============================================================================
+
+(defface emacs-openclaw-tool-face
+  '((t :foreground "dark orange" :weight normal :slant italic))
+  "Face for tool call/result lines in OpenClaw chat."
+  :group 'emacs-openclaw)
+
+(defun emacs-openclaw--log-tool-call (name args)
+  "Log a tool invocation to the chat buffer when tool activity display is enabled."
+  (when emacs-openclaw-show-tool-activity
+    (emacs-openclaw--log
+     (format "  ⚙ [tool] %s %s\n" name (or args ""))
+     'emacs-openclaw-tool-face)))
+
+(defun emacs-openclaw--log-tool-result (name result)
+  "Log a tool result to the chat buffer when tool activity display is enabled."
+  (when emacs-openclaw-show-tool-activity
+    (emacs-openclaw--log
+     (format "  ← [result] %s\n" (or result ""))
+     'shadow)))
 
 ;; ============================================================================
 ;; Agent Event Handling
@@ -47,6 +72,16 @@
             (setq emacs-openclaw--current-message-buffer
                   (concat emacs-openclaw--current-message-buffer delta))
             (emacs-openclaw--log delta nil)))
+
+         ((string= stream "tool_call")
+          (let ((name (or (alist-get 'name data) "unknown"))
+                (args (alist-get 'arguments data)))
+            (emacs-openclaw--log-tool-call name args)))
+
+         ((string= stream "tool_result")
+          (let ((name (or (alist-get 'name data) "unknown"))
+                (result (alist-get 'result data)))
+            (emacs-openclaw--log-tool-result name result)))
 
          ((and (string= stream "lifecycle")
                (string= (alist-get 'phase data) "end"))


### PR DESCRIPTION
## Summary
- Add `emacs-openclaw-show-tool-activity` config (default t) to toggle tool event display
- Handle `tool_call` and `tool_result` WebSocket stream events in the chat buffer
- Tool invocations appear as `⚙ [tool] name args` and results as `← [result] ...` in a distinct face

## Test plan
- [ ] Send a message that triggers a tool call (e.g. "list my buffers")
- [ ] Verify tool call and result lines appear in the chat buffer
- [ ] Set `emacs-openclaw-show-tool-activity` to nil and verify they are hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)