### PR TITLE
feat: log unknown WebSocket stream types for debugging

### DIFF
--- a/emacs-openclaw-websocket.el
+++ b/emacs-openclaw-websocket.el
@@ -57,7 +57,15 @@
           (when (> (length emacs-openclaw--current-message-buffer) 0)
             (emacs-openclaw-tts-speak-response emacs-openclaw--current-message-buffer))
           ;; Clear buffer for next response
-          (setq emacs-openclaw--current-message-buffer "")))))))
+          (setq emacs-openclaw--current-message-buffer ""))
+
+         (t
+          ;; Unknown stream type — log to server buffer for debugging
+          (let ((server-buf (get-buffer-create "*OpenClaw-Server*")))
+            (with-current-buffer server-buf
+              (goto-char (point-max))
+              (insert (format "[emacs-openclaw debug] Unknown stream type: %S data: %S\n"
+                              stream data)))))))))))
 ;; ----------------------------------------------------------------------------
 ;; Message handling
 ;; ----------------------------------------------------------------------------

--- a/emacs-openclaw-websocket.el
+++ b/emacs-openclaw-websocket.el
@@ -65,7 +65,7 @@
             (with-current-buffer server-buf
               (goto-char (point-max))
               (insert (format "[emacs-openclaw debug] Unknown stream type: %S data: %S\n"
-                              stream data)))))))))))
+                              stream data))))))))))
 ;; ----------------------------------------------------------------------------
 ;; Message handling
 ;; ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a fallthrough clause to the stream-type `cond` in `emacs-openclaw--handle-agent-event`
- Unknown stream types are logged to `*OpenClaw-Server*` buffer instead of silently dropped
- Zero impact on normal usage; aids debugging when the gateway protocol evolves

## Test plan
- [ ] Open `*OpenClaw-Server*` buffer
- [ ] Manually send a WebSocket frame with an unknown stream type and verify it appears in the debug buffer
- [ ] Verify normal assistant responses are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)