### PR TITLE
feat: add Thinking… indicator during agent processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,17 @@ The package includes a tool discovery mechanism that allows OpenClaw to know abo
 (setq emacs-openclaw-auto-start-server t)  ; Auto-start server (default: t)
 ```
 
+### Thinking Indicator
+
+While the agent is processing your message, a dimmed `Thinking…` line is shown
+in the chat buffer and automatically removed when the first response text
+arrives.  This is enabled by default; set it to `nil` to disable it:
+
+```elisp
+;; Disable the "Thinking…" indicator (default: t)
+(setq emacs-openclaw-show-thinking-indicator nil)
+```
+
 ### Customizing Chat Appearance
 
 You can customize the colors used in the chat buffer:

--- a/emacs-openclaw-config.el
+++ b/emacs-openclaw-config.el
@@ -61,6 +61,14 @@ If nil, will be auto-detected from the main session key provided by the gateway.
   :type 'boolean
   :group 'emacs-openclaw)
 
+(defcustom emacs-openclaw-show-thinking-indicator t
+  "Whether to show a \\='Thinking…\\=' indicator while the agent is processing.
+When non-nil, a dimmed \\='Thinking…\\=' line is inserted after the user sends
+a message and before the agent response arrives.  It is automatically
+cleared when the first response text streams in."
+  :type 'boolean
+  :group 'emacs-openclaw)
+
 (defcustom emacs-openclaw-python-executable "python3"
   "Python executable used to start the OpenClaw server.
 Defaults to \"python3\" (whatever is on your PATH), but you should set this

--- a/emacs-openclaw-websocket.el
+++ b/emacs-openclaw-websocket.el
@@ -104,7 +104,7 @@
               (when (> (length emacs-openclaw--current-message-buffer) 0)
                 (emacs-openclaw-tts-speak-response emacs-openclaw--current-message-buffer))
               ;; Clear buffer for next response
-              (setq emacs-openclaw--current-message-buffer "")))))))))))
+              (setq emacs-openclaw--current-message-buffer ""))))))))))
 ;; ----------------------------------------------------------------------------
 ;; Message handling
 ;; ----------------------------------------------------------------------------

--- a/emacs-openclaw-websocket.el
+++ b/emacs-openclaw-websocket.el
@@ -61,7 +61,8 @@
           (delete-region emacs-openclaw--thinking-marker
                          (save-excursion
                            (goto-char emacs-openclaw--thinking-marker)
-                           (line-end-position 2))))))
+                           (forward-line 1)
+                           (point))))))
     (set-marker emacs-openclaw--thinking-marker nil)
     (setq emacs-openclaw--thinking-marker nil)))
 

--- a/emacs-openclaw-websocket.el
+++ b/emacs-openclaw-websocket.el
@@ -41,7 +41,10 @@
 
 (defun emacs-openclaw--show-thinking ()
   "Insert a \\='Thinking…\\=' indicator in the chat buffer and record its position."
-  (when-let ((buf (get-buffer "*OpenClaw-Chat*")))
+  (emacs-openclaw--clear-thinking)
+  (when-let ((buf (get-buffer (if (boundp 'emacs-openclaw-buffer-name)
+                                  emacs-openclaw-buffer-name
+                                "*OpenClaw-Chat*"))))
     (with-current-buffer buf
       (let ((inhibit-read-only t))
         (save-excursion
@@ -50,7 +53,7 @@
             (insert (propertize "  Thinking…\n" 'face 'emacs-openclaw-thinking-face))
             (setq emacs-openclaw--thinking-marker (copy-marker start))))
         (when-let ((win (get-buffer-window buf)))
-          (set-window-point win (point-max)))))))
+          (set-window-point win (point-max))))))
 
 (defun emacs-openclaw--clear-thinking ()
   "Remove the \\='Thinking…\\=' indicator from the chat buffer."

--- a/emacs-openclaw-websocket.el
+++ b/emacs-openclaw-websocket.el
@@ -15,6 +15,9 @@
 
 (defvar emacs-openclaw--connect-nonce nil)
 
+(defvar emacs-openclaw--thinking-marker nil
+  "Buffer position marker for the \\='Thinking…\\=' indicator, or nil if not shown.")
+
 (defun emacs-openclaw--ensure-session-key ()
   (unless emacs-openclaw--session-key
     (setq emacs-openclaw--session-key
@@ -24,6 +27,43 @@
 (defun emacs-openclaw--generate-request-id ()
   (setq emacs-openclaw--request-id-counter (1+ emacs-openclaw--request-id-counter))
   (format "emacs-req-%d" emacs-openclaw--request-id-counter))
+
+;; ============================================================================
+;; Thinking Indicator
+;; ============================================================================
+
+(declare-function emacs-openclaw--log "emacs-openclaw-chat")
+
+(defface emacs-openclaw-thinking-face
+  '((t :foreground "gray50" :slant italic))
+  "Face for the \\='Thinking…\\=' indicator in OpenClaw chat."
+  :group 'emacs-openclaw)
+
+(defun emacs-openclaw--show-thinking ()
+  "Insert a \\='Thinking…\\=' indicator in the chat buffer and record its position."
+  (when-let ((buf (get-buffer "*OpenClaw-Chat*")))
+    (with-current-buffer buf
+      (let ((inhibit-read-only t))
+        (save-excursion
+          (goto-char (point-max))
+          (let ((start (point)))
+            (insert (propertize "  Thinking…\n" 'face 'emacs-openclaw-thinking-face))
+            (setq emacs-openclaw--thinking-marker (copy-marker start))))
+        (when-let ((win (get-buffer-window buf)))
+          (set-window-point win (point-max)))))))
+
+(defun emacs-openclaw--clear-thinking ()
+  "Remove the \\='Thinking…\\=' indicator from the chat buffer."
+  (when emacs-openclaw--thinking-marker
+    (when-let ((buf (marker-buffer emacs-openclaw--thinking-marker)))
+      (with-current-buffer buf
+        (let ((inhibit-read-only t))
+          (delete-region emacs-openclaw--thinking-marker
+                         (save-excursion
+                           (goto-char emacs-openclaw--thinking-marker)
+                           (line-end-position 2))))))
+    (set-marker emacs-openclaw--thinking-marker nil)
+    (setq emacs-openclaw--thinking-marker nil)))
 
 ;; ============================================================================
 ;; Agent Event Handling
@@ -43,21 +83,28 @@
             (data (alist-get 'data payload)))
         (cond
          ((string= stream "assistant")
+          (emacs-openclaw--clear-thinking)
           (when-let ((delta (alist-get 'delta data)))
             (setq emacs-openclaw--current-message-buffer
                   (concat emacs-openclaw--current-message-buffer delta))
             (emacs-openclaw--log delta nil)))
 
-         ((and (string= stream "lifecycle")
-               (string= (alist-get 'phase data) "end"))
-          (emacs-openclaw--log "\n" nil)
-          (emacs-openclaw--log (concat emacs-openclaw-message-separator "\n") 'shadow)
-          (emacs-openclaw--log "\n" nil)
-          ;; Speak the complete response if TTS is enabled
-          (when (> (length emacs-openclaw--current-message-buffer) 0)
-            (emacs-openclaw-tts-speak-response emacs-openclaw--current-message-buffer))
-          ;; Clear buffer for next response
-          (setq emacs-openclaw--current-message-buffer "")))))))
+         ((string= stream "lifecycle")
+          (let ((phase (alist-get 'phase data)))
+            (cond
+             ((string= phase "start")
+              (when emacs-openclaw-show-thinking-indicator
+                (emacs-openclaw--show-thinking)))
+             ((string= phase "end")
+              (emacs-openclaw--clear-thinking)
+              (emacs-openclaw--log "\n" nil)
+              (emacs-openclaw--log (concat emacs-openclaw-message-separator "\n") 'shadow)
+              (emacs-openclaw--log "\n" nil)
+              ;; Speak the complete response if TTS is enabled
+              (when (> (length emacs-openclaw--current-message-buffer) 0)
+                (emacs-openclaw-tts-speak-response emacs-openclaw--current-message-buffer))
+              ;; Clear buffer for next response
+              (setq emacs-openclaw--current-message-buffer "")))))))))))
 ;; ----------------------------------------------------------------------------
 ;; Message handling
 ;; ----------------------------------------------------------------------------


### PR DESCRIPTION
- [x] Identify actionable comments
- [x] Add README documentation for `emacs-openclaw-show-thinking-indicator`
- [x] Use `emacs-openclaw-buffer-name` (with fallback) instead of hardcoded `"*OpenClaw-Chat*"` in `emacs-openclaw--show-thinking`
- [x] Guard against re-insertion: call `emacs-openclaw--clear-thinking` at the start of `emacs-openclaw--show-thinking`

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.