### PR TITLE
feat: inject Emacs buffer context into outgoing messages

### DIFF
--- a/emacs-openclaw-chat.el
+++ b/emacs-openclaw-chat.el
@@ -78,6 +78,29 @@
 ;; Chat Request Handling
 ;; ============================================================================
 
+(defun emacs-openclaw--build-context-prefix ()
+  "Return a context string describing the user's current Emacs state.
+Returns nil if context injection is disabled or context is unavailable."
+  (when emacs-openclaw-inject-buffer-context
+    (condition-case nil
+        (let* ((prev-buf (other-buffer (get-buffer emacs-openclaw-buffer-name) t))
+               (buf-name (when (and prev-buf (buffer-live-p prev-buf))
+                           (buffer-name prev-buf)))
+               (file-path (when prev-buf
+                            (buffer-local-value 'buffer-file-name prev-buf)))
+               (mode (when prev-buf
+                       (symbol-name (buffer-local-value 'major-mode prev-buf))))
+               (line (when prev-buf
+                       (with-current-buffer prev-buf
+                         (line-number-at-pos)))))
+          (when buf-name
+            (format "[Context: buffer=%s%s, mode=%s, line=%s]\n"
+                    buf-name
+                    (if file-path (format " (%s)" file-path) "")
+                    (or mode "unknown")
+                    (or line "?"))))
+      (error nil))))
+
 (defun emacs-openclaw--send-request (prompt)
   "Send PROMPT to OpenClaw via websocket and log the response."
   (emacs-openclaw--log "\n" nil)
@@ -88,36 +111,37 @@
   (emacs-openclaw--log "\n" nil)
   (emacs-openclaw--log "OpenClaw: " 'emacs-openclaw-response-face)
   (emacs-openclaw--log "\n" nil)  ; Start response on new line
-  
-  (emacs-openclaw--websocket-send-chat 
-   prompt
-   (lambda (response)
-     (let ((ok (alist-get 'ok response))
-           (msg-id (alist-get 'id response))
-           (response-text nil))
-       (if ok
-           (progn
-             ;; Only extract from res if no agent events were received
-             ;; (agent events already streamed and displayed the response)
-             (unless (gethash msg-id emacs-openclaw--active-requests)
-               (let* ((payload (alist-get 'payload response))
-                      (result (alist-get 'result payload))
-                      (payloads (alist-get 'payloads result))
-                      (first-payload (when (listp payloads) (car payloads))))
-                 (setq response-text (when first-payload (alist-get 'text first-payload)))
-                 (when response-text
-                   (emacs-openclaw--log response-text nil)
-                   (emacs-openclaw--log "\n" nil)
-                   (emacs-openclaw--log (concat emacs-openclaw-message-separator "\n") 'shadow)
-                   (emacs-openclaw--log "\n" nil))))
-             ;; Clean up tracking
-             (remhash msg-id emacs-openclaw--active-requests)
-             ;; Speak the response if TTS is enabled
-             (when response-text
-               (emacs-openclaw-tts-speak-response response-text)))
-         (let ((error-data (alist-get 'error response)))
-           (emacs-openclaw--log (format "\n[Error]: %s\n" error-data) 'error)
-           (emacs-openclaw--log (concat emacs-openclaw-message-separator "\n") 'shadow)))))))
+
+  (let ((payload (concat (or (emacs-openclaw--build-context-prefix) "") prompt)))
+    (emacs-openclaw--websocket-send-chat
+     payload
+     (lambda (response)
+       (let ((ok (alist-get 'ok response))
+             (msg-id (alist-get 'id response))
+             (response-text nil))
+         (if ok
+             (progn
+               ;; Only extract from res if no agent events were received
+               ;; (agent events already streamed and displayed the response)
+               (unless (gethash msg-id emacs-openclaw--active-requests)
+                 (let* ((payload (alist-get 'payload response))
+                        (result (alist-get 'result payload))
+                        (payloads (alist-get 'payloads result))
+                        (first-payload (when (listp payloads) (car payloads))))
+                   (setq response-text (when first-payload (alist-get 'text first-payload)))
+                   (when response-text
+                     (emacs-openclaw--log response-text nil)
+                     (emacs-openclaw--log "\n" nil)
+                     (emacs-openclaw--log (concat emacs-openclaw-message-separator "\n") 'shadow)
+                     (emacs-openclaw--log "\n" nil))))
+               ;; Clean up tracking
+               (remhash msg-id emacs-openclaw--active-requests)
+               ;; Speak the response if TTS is enabled
+               (when response-text
+                 (emacs-openclaw-tts-speak-response response-text)))
+           (let ((error-data (alist-get 'error response)))
+             (emacs-openclaw--log (format "\n[Error]: %s\n" error-data) 'error)
+             (emacs-openclaw--log (concat emacs-openclaw-message-separator "\n") 'shadow))))))))
 
 ;; ============================================================================
 ;; Interactive Commands

--- a/emacs-openclaw-config.el
+++ b/emacs-openclaw-config.el
@@ -61,6 +61,16 @@ If nil, will be auto-detected from the main session key provided by the gateway.
   :type 'boolean
   :group 'emacs-openclaw)
 
+(defcustom emacs-openclaw-inject-buffer-context t
+  "Whether to automatically inject current buffer context into each message.
+When non-nil, a compact context block is prepended to the text sent to
+the OpenClaw gateway (but NOT shown in the chat buffer).  This saves
+the agent a round-trip tool call to discover what you are working on.
+The context includes: current buffer name, file path, major mode, and
+cursor line number."
+  :type 'boolean
+  :group 'emacs-openclaw)
+
 (defcustom emacs-openclaw-python-executable "python3"
   "Python executable used to start the OpenClaw server.
 Defaults to \"python3\" (whatever is on your PATH), but you should set this


### PR DESCRIPTION
## Summary
- Add `emacs-openclaw-inject-buffer-context` config (default t)
- Prepend a compact context block (buffer, file, mode, line) to messages sent to the gateway
- The chat buffer still shows only the plain user prompt — context is wire-only

## Test plan
- [ ] Send a message and verify the agent knows your current buffer without calling list_buffers
- [ ] Set `emacs-openclaw-inject-buffer-context` to nil and verify the agent no longer has context
- [ ] Verify the chat buffer shows only the plain prompt (no context prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)